### PR TITLE
Bump version to 1.0.0

### DIFF
--- a/examples/web_viewer/client/package.json
+++ b/examples/web_viewer/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fdl-viewer-client",
-  "version": "0.1.0-dev.11",
+  "version": "1.0.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/examples/web_viewer/server/package.json
+++ b/examples/web_viewer/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fdl-viewer-server",
-  "version": "0.1.0-dev.11",
+  "version": "1.0.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/native/bindings/node/package.json
+++ b/native/bindings/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@asc-mitc/fdl",
-  "version": "0.1.0-dev.11",
+  "version": "1.0.0",
   "description": "Node.js/TypeScript bindings for the ASC Framing Decision List (FDL) library",
   "type": "module",
   "main": "./dist/index.js",

--- a/native/bindings/python/pyproject.toml
+++ b/native/bindings/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "asc-fdl"
-version = "0.1.0-dev.11"
+version = "1.0.0"
 description = "Python CFFI bindings and wrapper for libfdl_core"
 license = "Apache-2.0"
 requires-python = ">=3.10"

--- a/native/core/cmake/FDLVersion.cmake
+++ b/native/core/cmake/FDLVersion.cmake
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2024-present American Society Of Cinematographers
 # SPDX-License-Identifier: Apache-2.0
-set(FDL_CORE_VERSION      "0.1.0")       # numeric-only — required by project(VERSION)
-set(FDL_CORE_VERSION_FULL "0.1.0-dev.11") # full version including pre-release suffix
+set(FDL_CORE_VERSION      "1.0.0")       # numeric-only — required by project(VERSION)
+set(FDL_CORE_VERSION_FULL "1.0.0") # full version including pre-release suffix
 # ABI version is independent of the package version — bump only when the C ABI changes.
 set(FDL_ABI_VERSION_MAJOR 0)
 set(FDL_ABI_VERSION_MINOR 6)

--- a/packages/fdl_frameline_generator/pyproject.toml
+++ b/packages/fdl_frameline_generator/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "asc-fdl-frameline-generator"
-version = "0.1.0-dev.11"
+version = "1.0.0"
 description = "Generate frameline overlay images from FDL files (EXR/PNG/TIFF via OIIO, plus SVG vector output)"
 license = "Apache-2.0"
 requires-python = ">=3.10"

--- a/packages/fdl_imaging/pyproject.toml
+++ b/packages/fdl_imaging/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "asc-fdl-imaging"
-version = "0.1.0-dev.11"
+version = "1.0.0"
 description = "FDL-based image processing using OpenImageIO"
 license = "Apache-2.0"
 requires-python = ">=3.10"

--- a/packages/fdl_viewer/pyproject.toml
+++ b/packages/fdl_viewer/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "asc-fdl-viewer"
-version = "0.1.0-dev.11"
+version = "1.0.0"
 description = "PySide6-based FDL Viewer application for viewing and transforming Framing Decision List files"
 license = "Apache-2.0"
 requires-python = ">=3.10"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "fdl-workspace"
-version = "0.1.0-dev.11"
+version = "1.0.0"
 license = "Apache-2.0"
 requires-python = ">=3.10"
 dependencies = [

--- a/uv.lock
+++ b/uv.lock
@@ -58,7 +58,7 @@ wheels = [
 
 [[package]]
 name = "asc-fdl"
-version = "0.1.0.dev9"
+version = "1.0.0"
 source = { editable = "native/bindings/python" }
 dependencies = [
     { name = "cffi" },
@@ -86,7 +86,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "asc-fdl-frameline-generator"
-version = "0.1.0.dev9"
+version = "1.0.0"
 source = { editable = "packages/fdl_frameline_generator" }
 dependencies = [
     { name = "asc-fdl" },
@@ -114,7 +114,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "asc-fdl-imaging"
-version = "0.1.0.dev9"
+version = "1.0.0"
 source = { editable = "packages/fdl_imaging" }
 dependencies = [
     { name = "asc-fdl" },
@@ -138,7 +138,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "asc-fdl-viewer"
-version = "0.1.0.dev9"
+version = "1.0.0"
 source = { editable = "packages/fdl_viewer" }
 dependencies = [
     { name = "asc-fdl" },
@@ -624,7 +624,7 @@ wheels = [
 
 [[package]]
 name = "fdl-workspace"
-version = "0.1.0.dev9"
+version = "1.0.0"
 source = { virtual = "." }
 dependencies = [
     { name = "asc-fdl" },


### PR DESCRIPTION
Update version from 0.1.0-dev.11 to 1.0.0 across all packages: pyproject.toml, native C++/Python/Node bindings, web viewer example, fdl_imaging, fdl_viewer, fdl_frameline_generator, and uv.lock.