### PR TITLE
Ensure UI Treats Labels Throughout As Display

### DIFF
--- a/packages/fdl_frameline_generator/src/fdl_frameline_generator/cli.py
+++ b/packages/fdl_frameline_generator/src/fdl_frameline_generator/cli.py
@@ -393,11 +393,38 @@ def main(args: list[str] | None = None) -> int:
         if parsed_args.framing:
             print(f"  Framing: {parsed_args.framing}")
 
+    # Resolve context argument: try label first, then index
+    context_index = None
+    if parsed_args.context is not None:
+        from fdl import read_from_file
+
+        fdl = read_from_file(parsed_args.input)
+
+        # First, try to match as a context label
+        for i, ctx in enumerate(fdl.contexts):
+            if ctx.label == parsed_args.context:
+                context_index = i
+                break
+
+        # If no label match, try as a numeric index
+        if context_index is None:
+            if parsed_args.context.isdigit():
+                context_index = int(parsed_args.context)
+            else:
+                print(f"Error: '{parsed_args.context}' is not a valid context label or index")
+                return 1
+
+        # Validate index is in range
+        num_contexts = len(fdl.contexts)
+        if context_index < 0 or context_index >= num_contexts:
+            print(f"Error: Context index {context_index} out of range (0-{num_contexts - 1})")
+            return 1
+
     try:
         success = renderer.render_from_fdl(
             fdl_path=parsed_args.input,
             output_path=parsed_args.output,
-            context_label=parsed_args.context,
+            context_index=context_index,
             canvas_id=parsed_args.canvas,
             framing_id=parsed_args.framing,
         )

--- a/packages/fdl_frameline_generator/src/fdl_frameline_generator/renderer.py
+++ b/packages/fdl_frameline_generator/src/fdl_frameline_generator/renderer.py
@@ -19,7 +19,6 @@ from fdl import (
     Context,
     FramingDecision,
     find_by_id,
-    find_by_label,
     read_from_file,
 )
 from OpenImageIO import FLOAT, ImageBuf, ImageBufAlgo, ImageSpec
@@ -267,7 +266,7 @@ class FramelineRenderer:
         self,
         fdl_path: str | Path,
         output_path: str | Path,
-        context_label: str | None = None,
+        context_index: int | None = None,
         canvas_id: str | None = None,
         framing_id: str | None = None,
     ) -> bool:
@@ -280,8 +279,8 @@ class FramelineRenderer:
             Path to the input FDL file.
         output_path : str or Path
             Path for the output image file.
-        context_label : str, optional
-            Context label to use. If None, uses the first context.
+        context_index : int, optional
+            Context index to use. If None, uses the first context.
         canvas_id : str, optional
             Canvas ID to use. If None, uses the first canvas.
         framing_id : str, optional
@@ -308,7 +307,7 @@ class FramelineRenderer:
             raise FileNotFoundError(f"FDL file not found: {fdl_path}")
 
         fdl = read_from_file(fdl_path)
-        _context, canvas, framing = self._get_fdl_components(fdl, context_label, canvas_id, framing_id)
+        _context, canvas, framing = self._get_fdl_components(fdl, context_index, canvas_id, framing_id)
 
         if output_path.suffix.lower() == ".svg":
             return self._render_and_write_svg(canvas, framing, output_path)
@@ -321,7 +320,7 @@ class FramelineRenderer:
         self,
         fdl: FDL,
         output_path: str | Path,
-        context_label: str | None = None,
+        context_index: int | None = None,
         canvas_id: str | None = None,
         framing_id: str | None = None,
     ) -> bool:
@@ -334,8 +333,8 @@ class FramelineRenderer:
             The FDL object containing framing data.
         output_path : str or Path
             Path for the output image file. Use .svg extension for vector output.
-        context_label : str, optional
-            Context label to use. If None, uses the first context.
+        context_index : int, optional
+            Context index to use. If None, uses the first context.
         canvas_id : str, optional
             Canvas ID to use. If None, uses the first canvas.
         framing_id : str, optional
@@ -355,7 +354,7 @@ class FramelineRenderer:
         """
         output_path = Path(output_path)
 
-        _context, canvas, framing = self._get_fdl_components(fdl, context_label, canvas_id, framing_id)
+        _context, canvas, framing = self._get_fdl_components(fdl, context_index, canvas_id, framing_id)
 
         if output_path.suffix.lower() == ".svg":
             return self._render_and_write_svg(canvas, framing, output_path)
@@ -367,7 +366,7 @@ class FramelineRenderer:
     def render_to_buffer(
         self,
         fdl: FDL,
-        context_label: str | None = None,
+        context_index: int | None = None,
         canvas_id: str | None = None,
         framing_id: str | None = None,
     ) -> ImageBuf:
@@ -378,8 +377,8 @@ class FramelineRenderer:
         ----------
         fdl : FDL
             The FDL object containing framing data.
-        context_label : str, optional
-            Context label to use. If None, uses the first context.
+        context_index : int, optional
+            Context index to use. If None, uses the first context.
         canvas_id : str, optional
             Canvas ID to use. If None, uses the first canvas.
         framing_id : str, optional
@@ -395,7 +394,7 @@ class FramelineRenderer:
         ValueError
             If the specified context, canvas, or framing decision is not found.
         """
-        _context, canvas, framing = self._get_fdl_components(fdl, context_label, canvas_id, framing_id)
+        _context, canvas, framing = self._get_fdl_components(fdl, context_index, canvas_id, framing_id)
 
         buf = self._create_image_buffer(canvas)
         self._render_all_layers(buf, canvas, framing)
@@ -405,7 +404,7 @@ class FramelineRenderer:
     def render_to_svg(
         self,
         fdl: FDL,
-        context_label: str | None = None,
+        context_index: int | None = None,
         canvas_id: str | None = None,
         framing_id: str | None = None,
     ) -> str:
@@ -416,8 +415,8 @@ class FramelineRenderer:
         ----------
         fdl : FDL
             The FDL object containing framing data.
-        context_label : str, optional
-            Context label to use. If None, uses the first context.
+        context_index : int, optional
+            Context index to use. If None, uses the first context.
         canvas_id : str, optional
             Canvas ID to use. If None, uses the first canvas.
         framing_id : str, optional
@@ -428,7 +427,7 @@ class FramelineRenderer:
         str
             The rendered SVG document as a string.
         """
-        _context, canvas, framing = self._get_fdl_components(fdl, context_label, canvas_id, framing_id)
+        _context, canvas, framing = self._get_fdl_components(fdl, context_index, canvas_id, framing_id)
         doc = self._build_svg_document(canvas, framing)
         return doc.to_string()
 
@@ -659,7 +658,7 @@ class FramelineRenderer:
     def _get_fdl_components(
         self,
         fdl: FDL,
-        context_label: str | None,
+        context_index: int | None,
         canvas_id: str | None,
         framing_id: str | None,
     ) -> tuple[Context, Canvas, FramingDecision]:
@@ -670,8 +669,8 @@ class FramelineRenderer:
         ----------
         fdl : FDL
             The FDL object to extract components from.
-        context_label : str or None
-            Context label to find. If None, uses first context.
+        context_index : int or None
+            Context index to use. If None, uses first context.
         canvas_id : str or None
             Canvas ID to find. If None, uses first canvas.
         framing_id : str or None
@@ -687,10 +686,11 @@ class FramelineRenderer:
         ValueError
             If the FDL has no contexts, or if specified components are not found.
         """
-        if context_label:
-            context = find_by_label(fdl.contexts, context_label)
-            if context is None:
-                raise ValueError(f"Context with label '{context_label}' not found")
+        if context_index is not None:
+            contexts = fdl.contexts
+            if context_index < 0 or context_index >= len(contexts):
+                raise ValueError(f"Context index {context_index} out of range")
+            context = contexts[context_index]
         else:
             if not fdl.contexts:
                 raise ValueError("FDL has no contexts")

--- a/packages/fdl_frameline_generator/tests/test_renderer.py
+++ b/packages/fdl_frameline_generator/tests/test_renderer.py
@@ -322,7 +322,7 @@ class TestRenderer:
         renderer = FramelineRenderer()
         buf = renderer.render_to_buffer(
             sample_fdl,
-            context_label="Test Context",
+            context_index=0,
             canvas_id="canvas1",
             framing_id="canvas1-TEST01",
         )
@@ -381,11 +381,11 @@ class TestRenderer:
         assert not buf.has_error
 
     def test_render_invalid_context(self, sample_fdl):
-        """Test that invalid context raises error."""
+        """Test that invalid context index raises error."""
         renderer = FramelineRenderer()
 
-        with pytest.raises(ValueError, match="not found"):
-            renderer.render_to_buffer(sample_fdl, context_label="Nonexistent")
+        with pytest.raises(ValueError, match="out of range"):
+            renderer.render_to_buffer(sample_fdl, context_index=999)
 
     def test_render_invalid_canvas(self, sample_fdl):
         """Test that invalid canvas raises error."""
@@ -394,7 +394,7 @@ class TestRenderer:
         with pytest.raises(ValueError, match="not found"):
             renderer.render_to_buffer(
                 sample_fdl,
-                context_label="Test Context",
+                context_index=0,
                 canvas_id="nonexistent",
             )
 
@@ -405,7 +405,7 @@ class TestRenderer:
         with pytest.raises(ValueError, match="not found"):
             renderer.render_to_buffer(
                 sample_fdl,
-                context_label="Test Context",
+                context_index=0,
                 canvas_id="canvas1",
                 framing_id="nonexistent",
             )

--- a/packages/fdl_imaging/src/fdl_imaging/_processing.py
+++ b/packages/fdl_imaging/src/fdl_imaging/_processing.py
@@ -18,7 +18,6 @@ from fdl import (
     Context,
     FramingDecision,
     find_by_id,
-    find_by_label,
     get_anchor_from_path,
     get_dimensions_from_path,
     read_from_file,
@@ -41,7 +40,7 @@ def _check_raster_output(output_path: Path) -> None:
 
 def get_fdl_components(
     fdl: FDL,
-    context_id: str,
+    context_index: int,
     canvas_id: str,
     framing_decision_id: str,
 ) -> tuple[Context, Canvas, FramingDecision]:
@@ -52,8 +51,8 @@ def get_fdl_components(
     ----------
     fdl : FDL
         The FDL object to search in
-    context_id : str
-        The context label (contexts use label as identifier)
+    context_index : int
+        The context index in the contexts array
     canvas_id : str
         The canvas ID to find
     framing_decision_id : str
@@ -69,15 +68,15 @@ def get_fdl_components(
     ValueError
         If any component is not found
     """
-    # Context uses label as identifier
-    context = find_by_label(fdl.contexts, context_id)
-    if context is None:
-        raise ValueError(f"No context with label '{context_id}'")
+    contexts = fdl.contexts
+    if context_index < 0 or context_index >= len(contexts):
+        raise ValueError(f"Context index {context_index} out of range")
+    context = contexts[context_index]
 
     # Find canvas by ID
     canvas = find_by_id(context.canvases, canvas_id)
     if canvas is None:
-        raise ValueError(f"No canvas with id '{canvas_id}' in context '{context_id}'")
+        raise ValueError(f"No canvas with id '{canvas_id}' in context index {context_index}")
 
     # Find framing decision by ID
     framing_decision = find_by_id(canvas.framing_decisions, framing_decision_id)

--- a/packages/fdl_imaging/src/fdl_imaging/_processing.py
+++ b/packages/fdl_imaging/src/fdl_imaging/_processing.py
@@ -90,7 +90,7 @@ def process_image_with_fdl(
     input_path: str | Path,
     output_path: str | Path,
     fdl: str | Path | FDL,
-    context_id: str,
+    context_index: int,
     canvas_id: str,
     framing_decision_id: str,
     use_protection: bool = True,
@@ -111,8 +111,8 @@ def process_image_with_fdl(
         Path where the processed image will be saved
     fdl : str, Path, or FDL
         The FDL file path or FDL object containing framing decisions
-    context_id : str
-        The context label to use
+    context_index : int
+        The context index in the contexts array
     canvas_id : str
         The canvas ID to use
     framing_decision_id : str
@@ -144,7 +144,7 @@ def process_image_with_fdl(
         fdl = read_from_file(fdl)
 
     # Get FDL components
-    _context, canvas, framing_decision = get_fdl_components(fdl, context_id, canvas_id, framing_decision_id)
+    _context, canvas, framing_decision = get_fdl_components(fdl, context_index, canvas_id, framing_decision_id)
 
     # Load the input image
     input_buf = ImageBuf(str(input_path))
@@ -208,7 +208,7 @@ def process_image_with_fdl_template(
     source_fdl: str | Path | FDL,
     template_fdl: str | Path | FDL,
     template_id: str,
-    context_id: str,
+    context_index: int,
     canvas_id: str,
     framing_decision_id: str,
     filter_name: str = "lanczos3",
@@ -237,8 +237,8 @@ def process_image_with_fdl_template(
         The template FDL file path or object containing canvas templates
     template_id : str
         The template ID to use
-    context_id : str
-        The context label to use
+    context_index : int
+        The context index in the contexts array
     canvas_id : str
         The canvas ID to use
     framing_decision_id : str
@@ -260,7 +260,7 @@ def process_image_with_fdl_template(
         template_fdl = read_from_file(template_fdl)
 
     # Get source FDL components
-    context, canvas, framing_decision = get_fdl_components(source_fdl, context_id, canvas_id, framing_decision_id)
+    context, canvas, framing_decision = get_fdl_components(source_fdl, context_index, canvas_id, framing_decision_id)
 
     # Find template
     template = find_by_id(template_fdl.canvas_templates, template_id)
@@ -301,7 +301,7 @@ def extract_framing_region(
     input_path: str | Path,
     output_path: str | Path,
     fdl: str | Path | FDL,
-    context_id: str,
+    context_index: int,
     canvas_id: str,
     framing_decision_id: str,
     output_width: int | None = None,
@@ -322,8 +322,8 @@ def extract_framing_region(
         Path where the processed image will be saved
     fdl : str, Path, or FDL
         The FDL file path or FDL object
-    context_id : str
-        The context label to use
+    context_index : int
+        The context index in the contexts array
     canvas_id : str
         The canvas ID to use
     framing_decision_id : str
@@ -349,7 +349,7 @@ def extract_framing_region(
         fdl = read_from_file(fdl)
 
     # Get FDL components
-    _context, _canvas, framing_decision = get_fdl_components(fdl, context_id, canvas_id, framing_decision_id)
+    _context, _canvas, framing_decision = get_fdl_components(fdl, context_index, canvas_id, framing_decision_id)
 
     # Load the input image
     input_buf = ImageBuf(str(input_path))

--- a/packages/fdl_imaging/src/fdl_imaging/testing/base.py
+++ b/packages/fdl_imaging/src/fdl_imaging/testing/base.py
@@ -8,6 +8,7 @@ Extends BaseFDLTestCase with image processing and comparison capabilities.
 
 from pathlib import Path
 
+from fdl import read_from_file
 from fdl.testing.base import BaseFDLTestCase
 
 from fdl_imaging import process_image_with_fdl_template
@@ -78,13 +79,17 @@ class BaseFDLImagingTestCase(BaseFDLTestCase):
             output_ext = source_image.suffix
         output_path = self.get_outputs_folder() / f"{test_name}_processed{output_ext}"
 
+        # Resolve context label to index
+        source_fdl = read_from_file(source_fdl_path)
+        context_index = next(i for i, c in enumerate(source_fdl.contexts) if c.label == context_label)
+
         process_image_with_fdl_template(
             input_path=source_image,
             output_path=output_path,
-            source_fdl=source_fdl_path,
+            source_fdl=source_fdl,
             template_fdl=template_fdl_path,
             template_id=template_id,
-            context_id=context_label,
+            context_index=context_index,
             canvas_id=canvas_id,
             framing_decision_id=framing_decision_id,
             filter_name=filter_name,

--- a/packages/fdl_imaging/tests/test_image_processing.py
+++ b/packages/fdl_imaging/tests/test_image_processing.py
@@ -30,10 +30,11 @@ class TestImageProcessing(BaseFDLTestCase):
         canvas = self.get_component_from_fdl(fdl, "canvas", label="Open Gate RAW", context=context)
         fd = self.get_component_from_fdl(fdl, "framing_decision", label="1.78-1 Framing", canvas=canvas)
 
-        # Test get_fdl_components function
+        # Test get_fdl_components function — resolve label to index
+        context_index = next(i for i, c in enumerate(fdl.contexts) if c.label == "RED Monstro")
         resolved_context, resolved_canvas, resolved_fd = get_fdl_components(
             fdl,
-            context_id="RED Monstro",
+            context_index=context_index,
             canvas_id=canvas.id,
             framing_decision_id=fd.id,
         )
@@ -43,13 +44,13 @@ class TestImageProcessing(BaseFDLTestCase):
         self.assertEqual(resolved_fd.id, fd.id)
 
     def test_get_fdl_components_invalid_context(self):
-        """Test that invalid context raises ValueError."""
+        """Test that invalid context index raises ValueError."""
         fdl_path = self.get_resources_folder() / "Source_OCF" / "Source_FDLs" / "A_5184x4320_2_20percentSafe.fdl"
         fdl = read_from_file(fdl_path)
 
         with self.assertRaises(ValueError) as cm:
-            get_fdl_components(fdl, "NonExistent", "1", "1-1")
-        self.assertIn("No context with label", str(cm.exception))
+            get_fdl_components(fdl, 999, "1", "1-1")
+        self.assertIn("Context index", str(cm.exception))
 
     def test_process_image_with_fdl_tif(self):
         """Test processing a TIF image with FDL."""
@@ -72,7 +73,7 @@ class TestImageProcessing(BaseFDLTestCase):
                 input_path=source_tif,
                 output_path=output_path,
                 fdl=source_fdl,
-                context_id=context.label,
+                context_index=next(i for i, c in enumerate(fdl.contexts) if c.label == context.label),
                 canvas_id=canvas.id,
                 framing_decision_id=fd.id,
                 use_protection=True,
@@ -115,7 +116,7 @@ class TestImageProcessing(BaseFDLTestCase):
                 input_path=source_tif,
                 output_path=output_path,
                 fdl=source_fdl,
-                context_id=context.label,
+                context_index=next(i for i, c in enumerate(fdl.contexts) if c.label == context.label),
                 canvas_id=canvas.id,
                 framing_decision_id=fd.id,
                 filter_name="triangle",
@@ -160,7 +161,7 @@ class TestImageProcessing(BaseFDLTestCase):
                 input_path=source_tif,
                 output_path=output_path,
                 fdl=source_fdl,
-                context_id=context.label,
+                context_index=next(i for i, c in enumerate(fdl.contexts) if c.label == context.label),
                 canvas_id=canvas.id,
                 framing_decision_id=fd.id,
                 output_width=target_width,
@@ -203,7 +204,7 @@ class TestImageProcessing(BaseFDLTestCase):
                     input_path=source_tif,
                     output_path=output_path,
                     fdl=other_fdl_path,
-                    context_id=context.label,
+                    context_index=next(i for i, c in enumerate(fdl.contexts) if c.label == context.label),
                     canvas_id=canvas.id,
                     framing_decision_id=fd.id,
                 )

--- a/packages/fdl_viewer/src/fdl_viewer/controllers/selection_controller.py
+++ b/packages/fdl_viewer/src/fdl_viewer/controllers/selection_controller.py
@@ -36,10 +36,10 @@ class SelectionController(QObject):
         Emitted when a complete selection is made (context, canvas, framing).
     """
 
-    contexts_updated = Signal(list)  # List of context labels
+    contexts_updated = Signal(list)  # List of (index, display_label) tuples
     canvases_updated = Signal(list)  # List of (canvas_id, label) tuples
     framings_updated = Signal(list)  # List of (fd_id, label) tuples
-    selection_complete = Signal(str, str, str)  # context_label, canvas_id, fd_id
+    selection_complete = Signal(int, str, str)  # context_index, canvas_id, fd_id
 
     def __init__(self, parent: QObject | None = None) -> None:
         """
@@ -72,27 +72,28 @@ class SelectionController(QObject):
             self.contexts_updated.emit([])
             return
 
-        labels = self._fdl_model.context_labels
-        self.contexts_updated.emit(labels)
+        contexts = self._fdl_model.contexts
+        context_list = [(i, ctx.label or str(i)) for i, ctx in enumerate(contexts)]
+        self.contexts_updated.emit(context_list)
 
         # Auto-select first if available
-        if labels:
-            self.select_context(labels[0])
+        if context_list:
+            self.select_context(context_list[0][0])
 
-    def select_context(self, label: str) -> None:
+    def select_context(self, index: int) -> None:
         """
-        Select a context by label.
+        Select a context by index.
 
         Parameters
         ----------
-        label : str
-            The context label to select.
+        index : int
+            The context index in the contexts array.
         """
         if self._fdl_model is None:
             return
 
-        self._fdl_model.set_context(label)
-        self._app_state.set_selection(label, "", "")
+        self._fdl_model.set_context(index)
+        self._app_state.set_selection(index, "", "")
         self._update_canvases()
 
     def _update_canvases(self) -> None:
@@ -122,8 +123,8 @@ class SelectionController(QObject):
             return
 
         self._fdl_model.set_canvas(canvas_id)
-        context_label = self._fdl_model._selected_context_label
-        self._app_state.set_selection(context_label, canvas_id, "")
+        context_index = self._fdl_model._selected_context_index
+        self._app_state.set_selection(context_index, canvas_id, "")
         self._update_framings()
 
     def _update_framings(self) -> None:
@@ -167,22 +168,22 @@ class SelectionController(QObject):
             return
 
         self._fdl_model.set_framing_decision(fd_id)
-        context_label = self._fdl_model._selected_context_label
+        context_index = self._fdl_model._selected_context_index
         canvas_id = self._fdl_model._selected_canvas_id
-        self._app_state.set_selection(context_label, canvas_id, fd_id)
-        self.selection_complete.emit(context_label, canvas_id, fd_id)
+        self._app_state.set_selection(context_index, canvas_id, fd_id)
+        self.selection_complete.emit(context_index, canvas_id, fd_id)
 
-    def get_current_selection(self) -> tuple[str, str, str]:
+    def get_current_selection(self) -> tuple[int, str, str]:
         """
         Get the current selection.
 
         Returns
         -------
         tuple
-            (context_label, canvas_id, framing_id)
+            (context_index, canvas_id, framing_id)
         """
         if self._fdl_model is None:
-            return ("", "", "")
+            return (-1, "", "")
         return self._fdl_model.selection_ids
 
     def get_selected_context(self) -> object:

--- a/packages/fdl_viewer/src/fdl_viewer/controllers/transform_controller.py
+++ b/packages/fdl_viewer/src/fdl_viewer/controllers/transform_controller.py
@@ -13,7 +13,6 @@ from fdl import (
     CanvasTemplate,
     TemplateResult,
     find_by_id,
-    find_by_label,
 )
 from PySide6.QtCore import QObject, Signal
 
@@ -65,7 +64,7 @@ class TransformController(QObject):
         self,
         source_fdl: FDL,
         template: CanvasTemplate,
-        context_label: str,
+        context_index: int,
         canvas_id: str,
         framing_decision_id: str,
         new_fd_name: str = "",
@@ -80,8 +79,8 @@ class TransformController(QObject):
             The source FDL to transform.
         template : CanvasTemplate
             The template to apply.
-        context_label : str
-            The label of the context to use.
+        context_index : int
+            The index of the context to use.
         canvas_id : str
             The ID of the canvas to use.
         framing_decision_id : str
@@ -104,10 +103,11 @@ class TransformController(QObject):
         self.transform_started.emit()
 
         try:
-            # Find the source context
-            context = find_by_label(source_fdl.contexts, context_label)
-            if context is None:
-                raise ValueError(f"Context not found: {context_label}")
+            # Find the source context by index
+            contexts = source_fdl.contexts
+            if context_index < 0 or context_index >= len(contexts):
+                raise ValueError(f"Context index {context_index} out of range")
+            context = contexts[context_index]
 
             # Find the source canvas
             canvas = find_by_id(context.canvases, canvas_id)
@@ -141,7 +141,7 @@ class TransformController(QObject):
     def validate_selection(
         self,
         source_fdl: FDL,
-        context_label: str,
+        context_index: int,
         canvas_id: str,
         framing_decision_id: str,
     ) -> tuple[bool, str]:
@@ -152,8 +152,8 @@ class TransformController(QObject):
         ----------
         source_fdl : FDL
             The source FDL.
-        context_label : str
-            The context label.
+        context_index : int
+            The context index.
         canvas_id : str
             The canvas ID.
         framing_decision_id : str
@@ -167,9 +167,10 @@ class TransformController(QObject):
         if not source_fdl:
             return False, "No source FDL"
 
-        context = find_by_label(source_fdl.contexts, context_label)
-        if context is None:
-            return False, f"Context not found: {context_label}"
+        contexts = source_fdl.contexts
+        if context_index < 0 or context_index >= len(contexts):
+            return False, f"Context index {context_index} out of range"
+        context = contexts[context_index]
 
         canvas = find_by_id(context.canvases, canvas_id)
         if canvas is None:

--- a/packages/fdl_viewer/src/fdl_viewer/controllers/unit_test_export_controller.py
+++ b/packages/fdl_viewer/src/fdl_viewer/controllers/unit_test_export_controller.py
@@ -101,7 +101,7 @@ class UnitTestExportController(QObject):
         template_fdl: FDL,
         output_fdl: FDL,
         source_image_path: str | None,
-        context_label: str,
+        context_index: int,
         canvas_id: str,
         framing_id: str,
         input_dims: tuple[float, float],
@@ -124,8 +124,8 @@ class UnitTestExportController(QObject):
             The transformed output FDL.
         source_image_path : str, optional
             Path to the source image (if any).
-        context_label : str
-            The selected context label.
+        context_index : int
+            The selected context index.
         canvas_id : str
             The selected canvas ID.
         framing_id : str
@@ -178,6 +178,9 @@ class UnitTestExportController(QObject):
             result_fdl_name = f"Scen{scenario_number}-RESULT-{base_name}.fdl"
             result_fdl_dest = results_dir / result_fdl_name
             write_to_file(output_fdl, result_fdl_dest)
+
+            # Resolve context index to label for test config generation
+            context_label = source_fdl.contexts[context_index].label if context_index < len(source_fdl.contexts) else ""
 
             # Generate scenario config code
             config_code = self.generate_scenario_config_code(

--- a/packages/fdl_viewer/src/fdl_viewer/models/app_state.py
+++ b/packages/fdl_viewer/src/fdl_viewer/models/app_state.py
@@ -64,7 +64,7 @@ class AppState(QObject):
     output_fdl_changed = Signal(object)  # FDLModel or None
 
     # Selection signals
-    selection_changed = Signal(str, str, str)  # context_label, canvas_id, framing_id
+    selection_changed = Signal(int, str, str)  # context_index, canvas_id, framing_id
     template_modified_changed = Signal(bool)
 
     # UI state signals
@@ -104,7 +104,7 @@ class AppState(QObject):
         self._output_fdl: FDLModel | None = None
 
         # Selection state
-        self._selected_context: str = ""
+        self._selected_context: int = -1
         self._selected_canvas: str = ""
         self._selected_framing: str = ""
 
@@ -206,8 +206,8 @@ class AppState(QObject):
 
     # Selection
     @property
-    def selected_context(self) -> str:
-        """Get the selected context label."""
+    def selected_context(self) -> int:
+        """Get the selected context index."""
         return self._selected_context
 
     @property
@@ -220,14 +220,14 @@ class AppState(QObject):
         """Get the selected framing decision ID."""
         return self._selected_framing
 
-    def set_selection(self, context: str, canvas: str, framing: str) -> None:
+    def set_selection(self, context: int, canvas: str, framing: str) -> None:
         """
         Set the current selection.
 
         Parameters
         ----------
-        context : str
-            The context label.
+        context : int
+            The context index.
         canvas : str
             The canvas ID.
         framing : str

--- a/packages/fdl_viewer/src/fdl_viewer/models/fdl_model.py
+++ b/packages/fdl_viewer/src/fdl_viewer/models/fdl_model.py
@@ -14,7 +14,6 @@ from fdl import (
     Context,
     FramingDecision,
     find_by_id,
-    find_by_label,
 )
 from PySide6.QtCore import QObject, QPointF, QRectF, Signal
 
@@ -48,12 +47,12 @@ class FDLModel(QObject):
     --------
     >>> model = FDLModel(loaded_fdl)
     >>> model.fdl_changed.connect(on_fdl_changed)
-    >>> model.set_selection("Context Label", "canvas_id", "fd_id")
+    >>> model.set_selection(0, "canvas_id", "fd_id")
     """
 
     # Signals
     fdl_changed = Signal()
-    context_changed = Signal(str)
+    context_changed = Signal(int)
     canvas_changed = Signal(str)
     framing_decision_changed = Signal(str)
 
@@ -71,7 +70,7 @@ class FDLModel(QObject):
         super().__init__(parent)
         self._fdl: FDL | None = fdl
         self._file_path: str = ""
-        self._selected_context_label: str = ""
+        self._selected_context_index: int = -1
         self._selected_canvas_id: str = ""
         self._selected_framing_id: str = ""
 
@@ -97,7 +96,7 @@ class FDLModel(QObject):
             The FDL dataclass to wrap.
         """
         self._fdl = fdl
-        self._selected_context_label = ""
+        self._selected_context_index = -1
         self._selected_canvas_id = ""
         self._selected_framing_id = ""
         self.fdl_changed.emit()
@@ -155,7 +154,7 @@ class FDLModel(QObject):
         List[str]
             The list of context labels.
         """
-        return [ctx.label for ctx in self.contexts]
+        return [ctx.label or str(i) for i, ctx in enumerate(self.contexts)]
 
     @property
     def current_context(self) -> Context | None:
@@ -167,23 +166,26 @@ class FDLModel(QObject):
         Context or None
             The selected context, or None if not selected.
         """
-        if not self._selected_context_label or self._fdl is None:
+        if self._selected_context_index < 0 or self._fdl is None:
             return None
-        return find_by_label(self._fdl.contexts, self._selected_context_label)
+        contexts = self._fdl.contexts
+        if self._selected_context_index < len(contexts):
+            return contexts[self._selected_context_index]
+        return None
 
-    def set_context(self, label: str) -> None:
+    def set_context(self, index: int) -> None:
         """
-        Set the selected context by label.
+        Set the selected context by index.
 
         Parameters
         ----------
-        label : str
-            The context label.
+        index : int
+            The context index in the contexts array.
         """
-        self._selected_context_label = label
+        self._selected_context_index = index
         self._selected_canvas_id = ""
         self._selected_framing_id = ""
-        self.context_changed.emit(label)
+        self.context_changed.emit(index)
 
     # Canvas operations
     @property
@@ -344,23 +346,23 @@ class FDLModel(QObject):
         return None
 
     # Combined selection
-    def set_selection(self, context_label: str, canvas_id: str, fd_id: str) -> None:
+    def set_selection(self, context_index: int, canvas_id: str, fd_id: str) -> None:
         """
         Set the complete selection.
 
         Parameters
         ----------
-        context_label : str
-            The context label.
+        context_index : int
+            The context index in the contexts array.
         canvas_id : str
             The canvas ID.
         fd_id : str
             The framing decision ID.
         """
-        self._selected_context_label = context_label
+        self._selected_context_index = context_index
         self._selected_canvas_id = canvas_id
         self._selected_framing_id = fd_id
-        self.context_changed.emit(context_label)
+        self.context_changed.emit(context_index)
         self.canvas_changed.emit(canvas_id)
         self.framing_decision_changed.emit(fd_id)
 
@@ -374,7 +376,7 @@ class FDLModel(QObject):
         tuple
             (context_label, canvas_id, framing_id)
         """
-        return (self._selected_context_label, self._selected_canvas_id, self._selected_framing_id)
+        return (self._selected_context_index, self._selected_canvas_id, self._selected_framing_id)
 
     # Canvas templates
     @property

--- a/packages/fdl_viewer/src/fdl_viewer/views/main_window.py
+++ b/packages/fdl_viewer/src/fdl_viewer/views/main_window.py
@@ -444,23 +444,24 @@ class MainWindow(QMainWindow):
             self._show_error("No template configured")
             return
 
-        context_label, canvas_id, fd_id = (
+        context_index, canvas_id, fd_id = (
             self._app_state.selected_context,
             self._app_state.selected_canvas,
             self._app_state.selected_framing,
         )
 
-        if not context_label or not canvas_id or not fd_id:
+        if context_index < 0 or not canvas_id or not fd_id:
             self._show_error("Please select a context, canvas, and framing decision")
             return
 
         try:
-            result = self._transform_controller.apply_template(source.fdl, template, context_label, canvas_id, fd_id)
+            result = self._transform_controller.apply_template(source.fdl, template, context_index, canvas_id, fd_id)
 
             if result:
                 output_model = FDLModel(result.fdl)
                 # Auto-select the output context/canvas/framing for visualization
-                output_model.set_selection(result.context.label, result.canvas.id, result.framing_decision.id)
+                # Output FDL has a single context at index 0
+                output_model.set_selection(0, result.canvas.id, result.framing_decision.id)
                 self._app_state.set_output_fdl(output_model)
                 self._app_state.set_transform_result(result)
 
@@ -476,7 +477,7 @@ class MainWindow(QMainWindow):
                 if self._current_image_path:
                     self._transform_and_display_output_image(
                         source.fdl,
-                        context_label,
+                        context_index,
                         canvas_id,
                         fd_id,
                         template,
@@ -520,7 +521,7 @@ class MainWindow(QMainWindow):
     def _transform_and_display_output_image(
         self,
         source_fdl,
-        context_label: str,
+        context_index: int,
         canvas_id: str,
         fd_id: str,
         template,
@@ -535,8 +536,8 @@ class MainWindow(QMainWindow):
         ----------
         source_fdl : FDL
             The source FDL object
-        context_label : str
-            The selected context label
+        context_index : int
+            The selected context index
         canvas_id : str
             The selected canvas ID
         fd_id : str
@@ -552,7 +553,7 @@ class MainWindow(QMainWindow):
         """
         try:
             # Get source canvas and framing decision
-            _context, source_canvas, source_framing = get_fdl_components(source_fdl, context_label, canvas_id, fd_id)
+            _context, source_canvas, source_framing = get_fdl_components(source_fdl, context_index, canvas_id, fd_id)
 
             # Create a temporary file for the output image
             with tempfile.NamedTemporaryFile(suffix=".png", delete=False) as tmp_file:
@@ -792,10 +793,10 @@ class MainWindow(QMainWindow):
                 filter_name = AppSettings().get_image_filter()
 
             source_fdl = self._app_state.source_fdl.fdl
-            context_label = self._app_state.selected_context
+            context_index = self._app_state.selected_context
             canvas_id = self._app_state.selected_canvas
             fd_id = self._app_state.selected_framing
-            _context, source_canvas, source_framing = get_fdl_components(source_fdl, context_label, canvas_id, fd_id)
+            _context, source_canvas, source_framing = get_fdl_components(source_fdl, context_index, canvas_id, fd_id)
             template = self._app_state.current_template
             Path(output_path).parent.mkdir(parents=True, exist_ok=True)
             from fdl import ATTR_CONTENT_TRANSLATION, ATTR_SCALED_BOUNDING_BOX
@@ -913,7 +914,7 @@ class MainWindow(QMainWindow):
             export_config = dialog.get_export_config()
 
             # Get selection info
-            context_label = self._app_state.selected_context
+            context_index = self._app_state.selected_context
             canvas_id = self._app_state.selected_canvas
             framing_id = self._app_state.selected_framing
 
@@ -934,7 +935,7 @@ class MainWindow(QMainWindow):
                 template_fdl=template_fdl_model.fdl,
                 output_fdl=output_fdl.fdl,
                 source_image_path=self._current_image_path if export_config["include_image"] else None,
-                context_label=context_label,
+                context_index=context_index,
                 canvas_id=canvas_id,
                 framing_id=framing_id,
                 input_dims=input_dims,

--- a/packages/fdl_viewer/src/fdl_viewer/views/main_window.py
+++ b/packages/fdl_viewer/src/fdl_viewer/views/main_window.py
@@ -788,9 +788,9 @@ class MainWindow(QMainWindow):
             return False
         try:
             if filter_name is None:
-                from fdl_viewer.utils.settings import AppSettings
+                from fdl_viewer.utils.settings import Settings
 
-                filter_name = AppSettings().get_image_filter()
+                filter_name = Settings().get_image_filter()
 
             source_fdl = self._app_state.source_fdl.fdl
             context_index = self._app_state.selected_context

--- a/packages/fdl_viewer/src/fdl_viewer/views/sidebar/sidebar_widget.py
+++ b/packages/fdl_viewer/src/fdl_viewer/views/sidebar/sidebar_widget.py
@@ -244,7 +244,7 @@ class SidebarWidget(QWidget):
             self._app_state.selected_framing,
         )
 
-        enabled = source is not None and template is not None and bool(context) and bool(canvas) and bool(framing)
+        enabled = source is not None and template is not None and context >= 0 and bool(canvas) and bool(framing)
         self._transform_button.setEnabled(enabled)
 
         # Update button text and style based on template modification state

--- a/packages/fdl_viewer/src/fdl_viewer/views/sidebar/source_selector_view.py
+++ b/packages/fdl_viewer/src/fdl_viewer/views/sidebar/source_selector_view.py
@@ -32,14 +32,14 @@ class SourceSelectorView(QWidget):
     Attributes
     ----------
     context_selected : Signal
-        Emitted when a context is selected (label).
+        Emitted when a context is selected (index).
     canvas_selected : Signal
         Emitted when a canvas is selected (id).
     framing_selected : Signal
         Emitted when a framing decision is selected (id).
     """
 
-    context_selected = Signal(str)
+    context_selected = Signal(int)
     canvas_selected = Signal(str)
     framing_selected = Signal(str)
 
@@ -99,15 +99,17 @@ class SourceSelectorView(QWidget):
 
     def _connect_signals(self) -> None:
         """Connect signals."""
-        self._context_combo.currentTextChanged.connect(self._on_context_changed)
+        self._context_combo.currentIndexChanged.connect(self._on_context_changed)
         self._canvas_combo.currentIndexChanged.connect(self._on_canvas_changed)
         self._framing_combo.currentIndexChanged.connect(self._on_framing_changed)
 
-    @Slot(str)
-    def _on_context_changed(self, text: str) -> None:
+    @Slot(int)
+    def _on_context_changed(self, index: int) -> None:
         """Handle context selection change."""
-        if text:
-            self.context_selected.emit(text)
+        if index >= 0:
+            context_index = self._context_combo.currentData()
+            if context_index is not None:
+                self.context_selected.emit(context_index)
 
     @Slot(int)
     def _on_canvas_changed(self, index: int) -> None:
@@ -126,21 +128,22 @@ class SourceSelectorView(QWidget):
                 self.framing_selected.emit(fd_id)
 
     @Slot(list)
-    def set_contexts(self, labels: list[str]) -> None:
+    def set_contexts(self, contexts: list[tuple[int, str]]) -> None:
         """
         Set the available contexts.
 
         Parameters
         ----------
-        labels : List[str]
-            The list of context labels.
+        contexts : List[Tuple[int, str]]
+            List of (index, display_label) tuples.
         """
         self._context_combo.blockSignals(True)
         self._context_combo.clear()
-        self._context_combo.addItems(labels)
+        for index, display_label in contexts:
+            self._context_combo.addItem(display_label, index)
         self._context_combo.blockSignals(False)
 
-        if labels:
+        if contexts:
             self._context_combo.setCurrentIndex(0)
 
     @Slot(list)

--- a/packages/fdl_viewer/tests/test_controllers.py
+++ b/packages/fdl_viewer/tests/test_controllers.py
@@ -70,12 +70,12 @@ class TestTransformController:
 
     def test_validate_selection_missing_fdl(self, transform_controller):
         """Test validation fails with no FDL."""
-        is_valid, error = transform_controller.validate_selection(None, "context1", "canvas1", "framing1")
+        is_valid, error = transform_controller.validate_selection(None, 0, "canvas1", "framing1")
         assert not is_valid
         assert "No source FDL" in error
 
     def test_validate_selection_missing_context(self, transform_controller, sample_source_fdl_path):
-        """Test validation fails with missing context."""
+        """Test validation fails with out-of-range context index."""
         if not sample_source_fdl_path.exists():
             pytest.skip("Sample file not found")
 
@@ -83,9 +83,9 @@ class TestTransformController:
 
         fdl = read_from_file(sample_source_fdl_path)
 
-        is_valid, error = transform_controller.validate_selection(fdl, "nonexistent", "canvas1", "framing1")
+        is_valid, error = transform_controller.validate_selection(fdl, 999, "canvas1", "framing1")
         assert not is_valid
-        assert "Context not found" in error
+        assert "Context index" in error
 
     def test_validate_selection_valid(self, transform_controller, sample_source_fdl_path):
         """Test validation passes with valid selections."""
@@ -104,7 +104,7 @@ class TestTransformController:
         if not framing:
             pytest.skip("No framing decision in source")
 
-        is_valid, error = transform_controller.validate_selection(fdl, context.label, canvas.id, framing.id)
+        is_valid, error = transform_controller.validate_selection(fdl, 0, canvas.id, framing.id)
         assert is_valid
         assert error == ""
 
@@ -141,7 +141,7 @@ class TestTransformController:
         transform_controller.apply_template(
             source_fdl=source_fdl,
             template=template,
-            context_label=context.label,
+            context_index=0,
             canvas_id=canvas.id,
             framing_decision_id=framing.id,
         )
@@ -180,14 +180,12 @@ class TestSelectionController:
 
         selection_controller.set_fdl_model(model)
 
-        # Get a context label
-        context_label = fdl.contexts[0].label
-        selection_controller.select_context(context_label)
+        # Select first context by index
+        selection_controller.select_context(0)
 
         # Should be able to get selected context
         selected = selection_controller.get_selected_context()
         assert selected is not None
-        assert selected.label == context_label
 
     def test_select_canvas(self, qapp, app_state, selection_controller, sample_source_fdl_path):
         """Test selecting a canvas."""
@@ -202,10 +200,10 @@ class TestSelectionController:
         selection_controller.set_fdl_model(model)
 
         # Select context first
-        context = fdl.contexts[0]
-        selection_controller.select_context(context.label)
+        selection_controller.select_context(0)
 
         # Select canvas
+        context = fdl.contexts[0]
         canvas = context.canvases[0]
         selection_controller.select_canvas(canvas.id)
 
@@ -227,10 +225,10 @@ class TestSelectionController:
         selection_controller.set_fdl_model(model)
 
         # After setting model, selection should auto-cascade
-        context_label, canvas_id, _framing_id = selection_controller.get_current_selection()
+        context_index, canvas_id, _framing_id = selection_controller.get_current_selection()
 
         # Should have at least context and canvas selected
-        assert context_label != ""
+        assert context_index >= 0
         assert canvas_id != ""
 
 

--- a/packages/fdl_viewer/tests/test_integration.py
+++ b/packages/fdl_viewer/tests/test_integration.py
@@ -58,7 +58,7 @@ class TestEndToEndWorkflow:
         transform_controller.apply_template(
             source_fdl=source_model.fdl,
             template=template,
-            context_label=context.label,
+            context_index=0,
             canvas_id=canvas.id,
             framing_decision_id=framing.id,
         )

--- a/packages/fdl_viewer/tests/test_models.py
+++ b/packages/fdl_viewer/tests/test_models.py
@@ -33,8 +33,8 @@ class TestAppState:
         assert app_state.source_fdl is None
         assert app_state.template_fdl is None
         assert app_state.output_fdl is None
-        # Selection values default to empty string, not None
-        assert app_state.selected_context == ""
+        # Context defaults to -1 (no selection), canvas/framing default to empty string
+        assert app_state.selected_context == -1
         assert app_state.selected_canvas == ""
         assert app_state.selected_framing == ""
         assert app_state.active_tab == 0
@@ -103,7 +103,7 @@ class TestAppState:
         """Test resetting state via reset_instance."""
         mock_model = MagicMock(spec=FDLModel)
         app_state.set_source_fdl(mock_model)
-        app_state.set_selection("ctx", "canvas", "framing")
+        app_state.set_selection(0, "canvas", "framing")
 
         # Reset instance creates a fresh state
         AppState.reset_instance()
@@ -112,7 +112,7 @@ class TestAppState:
         assert new_state.source_fdl is None
         assert new_state.template_fdl is None
         assert new_state.output_fdl is None
-        assert new_state.selected_context == ""
+        assert new_state.selected_context == -1
 
 
 class TestFDLModel:

--- a/packages/fdl_viewer/tests/test_views.py
+++ b/packages/fdl_viewer/tests/test_views.py
@@ -355,13 +355,13 @@ class TestSourceSelectorView:
 
         widget = SourceSelectorView()
 
-        # Get context labels from FDL and set them
-        context_labels = [ctx.label for ctx in fdl.contexts]
-        widget.set_contexts(context_labels)
+        # Get context list as (index, display_label) tuples
+        context_list = [(i, ctx.label or str(i)) for i, ctx in enumerate(fdl.contexts)]
+        widget.set_contexts(context_list)
 
         # Should have contexts populated
         assert widget._context_combo.count() > 0
-        assert widget._context_combo.count() == len(context_labels)
+        assert widget._context_combo.count() == len(context_list)
 
 
 class TestTemplateEditorView:


### PR DESCRIPTION
Contexts in the FDL spec have no id field and label is optional. The viewer was using context labels as identifiers throughout the selection pipeline, which broke when a context had an empty label.

The underlying C++ core API already identifies contexts by array index via fdl_doc_context_at(). Aligned the Python layer to match by using index-based selection across the viewer, imaging, and frameline generator packages. Labels are still used for display in dropdowns with the array index as fallback when empty.